### PR TITLE
Show archetype.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
             <input type="text" id="jobtitle" name="jobtitle">
             <label for="askmeabout">Ask Me About <span style="font-style: italic; color: #666;">(45 character limit)</span> :</label>
             <input type="text" id="askmeabout" name="askmeabout" maxlength="45">
-            <!--label for="archetype">Growth Edge Archetype:</label-->
+            <label for="archetype">Growth Edge Archetype:</label>
             <div class="archetype-selector">
                 <div class="archetype-option" data-value="builder">
                     <img src="./archetypes/archetype-builder.png" alt="Builder" />

--- a/public/styles.css
+++ b/public/styles.css
@@ -87,7 +87,6 @@ input {
     grid-template-columns: repeat(3, 1fr);
     gap: 10px;
     margin-top: 10px;
-    display: none; /* hide by default */
 }
 
 .archetype-option {


### PR DESCRIPTION
**HTML Updates:**
* [`public/index.html`](diffhunk://#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cdL26-R26): Re-enabled the label for "Growth Edge Archetype" by uncommenting the corresponding HTML line.

**CSS Updates:**
* [`public/styles.css`](diffhunk://#diff-c0957aceb7c1368cd9919f48a72240ae31b22112283b1bd4d38c66a55ed584b9L90): Removed the `display: none;` property from the `input` selector, ensuring the archetype selector is visible by default.